### PR TITLE
Potential fix for code scanning alert no. 33: Log entries created from user input

### DIFF
--- a/WebAPI/Controllers/ForwardingController.cs
+++ b/WebAPI/Controllers/ForwardingController.cs
@@ -237,7 +237,8 @@ namespace WebAPI.Controllers
             try
             {
                 await _forwardingService.UpdateRuleAsync(rule, cancellationToken);
-                _logger.LogInformation("CONTROLLER.UpdateRule: Rule '{RuleName}' updated successfully.", rule.RuleName);
+                var sanitizedRuleName = rule.RuleName.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                _logger.LogInformation("CONTROLLER.UpdateRule: Rule '{RuleName}' updated successfully.", sanitizedRuleName);
                 return Ok();
             }
             catch (InvalidOperationException opEx)
@@ -264,7 +265,8 @@ namespace WebAPI.Controllers
             try
             {
                 await _forwardingService.DeleteRuleAsync(ruleName, cancellationToken);
-                _logger.LogInformation("CONTROLLER.DeleteRule: Rule '{RuleName}' deleted successfully.", ruleName);
+                var sanitizedRuleName = ruleName.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                _logger.LogInformation("CONTROLLER.DeleteRule: Rule '{RuleName}' deleted successfully.", sanitizedRuleName);
                 return Ok();
             }
             catch (InvalidOperationException opEx)


### PR DESCRIPTION
Potential fix for [https://github.com/Opselon/ForexTradingBot/security/code-scanning/33](https://github.com/Opselon/ForexTradingBot/security/code-scanning/33)

To fix the issue, sanitize the `ruleName` parameter before logging it. Since the logs are plain text, remove any newline characters from `ruleName` using `String.Replace`. This ensures that malicious users cannot inject newlines or other special characters into the logs.

Changes to be made:
1. Sanitize `ruleName` before logging it in the `DeleteRule` method.
2. Apply the same sanitization in the `UpdateRule` method for consistency.

No new dependencies are required, as the fix uses built-in string manipulation methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
